### PR TITLE
database.ymlの運用を変更し、git管理下に置く

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,6 @@ yarn-debug.log*
 .yarn-integrity
 
 #Ignore uploaded files in development
-/config/database.yml
+#credentialsの運用に切り替えたため、git管理下に変更
+#/config/database.yml
+/config/credentials/development.key

--- a/config/credentials/development.yml.enc
+++ b/config/credentials/development.yml.enc
@@ -1,0 +1,1 @@
+JF8oVWMorESHv/Zd5YpOu20VvSbV5ilwK+a/ngAPOASLb9nDLXg9Tq7r10VNkuqZgIgJn+aJ1ixH4USxOU1vn7t23c6Ykg==--9iZ1iL308YE4uNtM--yqHDfyiPgX7/fh3Efdzkgw==

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,55 @@
+# MySQL. Versions 5.5.8 and up are supported.
+#
+# Install the MySQL driver
+#   gem install mysql2
+#
+# Ensure the MySQL gem is defined in your Gemfile
+#   gem 'mysql2'
+#
+# And be sure to use new-style password hashing:
+#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
+#
+default: &default
+  adapter: mysql2
+  encoding: utf8mb4
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= Rails.application.credentials.mysql[:username] %>
+  password: <%= Rails.application.credentials.mysql[:password] %>
+  host: <%= Rails.application.credentials.mysql[:host] %>
+
+development:
+  <<: *default
+  database: blog_JT_development
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: blog_JT_test
+
+# As with config/credentials.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password or a full connection URL as an environment
+# variable when you boot the app. For example:
+#
+#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
+#
+# If the connection URL is provided in the special DATABASE_URL environment
+# variable, Rails will automatically merge its configuration values on top of
+# the values provided in this file. Alternatively, you can specify a connection
+# URL environment variable explicitly:
+#
+#   production:
+#     url: <%= ENV['MY_APP_DATABASE_URL'] %>
+#
+# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full overview on how database connection configuration can be specified.
+#
+production:
+  <<: *default
+  database: blog_JT_production
+  username: blog_JT
+  password: <%= ENV['BLOG_JT_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
## 背景
今までdatabase.ymlをgit管理下においていなかったが、GitHUB Actions等でファイルが必要になりそうなのでどうにかしたい。

## やったこと
Rails 6よりサポートされたMulti Environment Credentialsを使って、database.ymlにベタがきしていたパスワードを暗号化した。
[Rails 6よりサポートされたMulti Environment Credentialsをプロジェクトに導入する](https://zenn.dev/banrih/articles/f22f0a70bbead2a02110)

credential作成コード例
```
EDITOR='code --wait' rails credentials:edit -e development
EDITOR='code --wait' rails credentials:edit -e production

```

## やらなかったこと

## UIの変更箇所
