### PR TITLE
tagテーブルを追加

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/db/migrate/20210805131512_create_tags.rb
+++ b/db/migrate/20210805131512_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tags do |t|
+      t.integer :name, null: false
+      t.integer :article_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_05_125021) do
+ActiveRecord::Schema.define(version: 2021_08_05_131512) do
 
   create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title_ja"
@@ -28,6 +28,13 @@ ActiveRecord::Schema.define(version: 2021_08_05_125021) do
   create_table "places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "country", null: false
     t.integer "prefecture"
+    t.integer "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "name", null: false
     t.integer "article_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :tag do
+    name { 1 }
+    article_id { 1 }
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 背景
記事にタグをつけて将来的にそれでソートできるようにしたい。

## やったこと
tagテーブルを追加

tags |   |   |   |   |  
-- | -- | -- | -- | -- | --
カラム名 | 型 | デフォルト | 長さ | NULL | 内容
name | integer(active_hash) |   | 15 | FALSE |  
article_id |   |   |   |   |  



## やらなかったこと

## UIの変更箇所
