### PR TITLE
コメントテーブルを追加

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ApplicationRecord
+end

--- a/db/migrate/20210805132710_create_comments.rb
+++ b/db/migrate/20210805132710_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :content, null: false
+      t.integer :user_id, null: false
+      t.integer :article_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_05_131512) do
+ActiveRecord::Schema.define(version: 2021_08_05_132710) do
 
   create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title_ja"
@@ -23,6 +23,14 @@ ActiveRecord::Schema.define(version: 2021_08_05_131512) do
     t.text "content_en"
     t.integer "main_language", null: false
     t.integer "user_id", null: false
+  end
+
+  create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "content", null: false
+    t.integer "user_id", null: false
+    t.integer "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    content { "MyText" }
+    user_id { 1 }
+    article_id { 1 }
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 背景
コメント機能を将来的に追加するためにテーブルを追加したい。

## やったこと
テーブル追加

comments |   |   |   |   |  
-- | -- | -- | -- | -- | --
カラム名 | 型 | デフォルト | 長さ | NULL | 内容
comment | text |   | 300 | FALSE |  
user_id | integer |   |   | FALSE |  
article_id | integer |   |   | FALSE |  



## やらなかったこと

## UIの変更箇所
