### PR TITLE
マークダウンのスタイルが適用されるように変更

### DIFF
--- a/app/javascript/css/tailwindcss.css
+++ b/app/javascript/css/tailwindcss.css
@@ -1,3 +1,96 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+
+/* Markdown Styles */
+/* Global */
+.markdown {
+    @apply leading-relaxed text-sm　font-sans;
+}
+@screen sm {
+    .markdown {
+        @apply text-base;
+    }
+}
+@screen lg {
+    .markdown {
+        @apply text-lg;
+    }
+}
+
+/* Headers */
+.markdown h1,
+.markdown h2 {
+    @apply text-xl my-6;
+}
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+    @apply text-lg my-3 ;
+}
+@screen sm {
+    .markdown h1,
+    .markdown h2 {
+        @apply text-2xl;
+    }
+    .markdown h3,
+    .markdown h4,
+    .markdown h5,
+    .markdown h6 {
+        @apply text-xl;
+    }
+}
+
+/* Links */
+.markdown a {
+    @apply text-blue-600;
+}
+.markdown a:hover {
+    @apply underline;
+}
+
+/* Paragraph */
+.markdown p {
+    @apply mb-4 leading-8 md:leading-10 text-justify;
+}
+
+/* Lists */
+.markdown ul,
+.markdown ol {
+    @apply mb-4 ml-8;
+}
+.markdown li > p,
+.markdown li > ul,
+.markdown li > ol {
+    @apply mb-0;
+}
+.markdown ol {
+    @apply list-decimal;
+}
+.markdown ul {
+    @apply list-disc;
+}
+
+/* Blockquotes */
+.markdown blockquote {
+    @apply p-2 mx-2 my-2 bg-gray-100 mb-4 border-l-4 border-gray-400  rounded-r-lg;
+}
+.markdown blockquote > p {
+    @apply mb-0;
+}
+
+/* Images */
+.markdown img {
+    @apply shadow-lg;
+}
+
+/* Code */
+.markdown :not(pre) > code {
+    @apply bg-indigo-50 p-1 font-semibold text-gray-600 rounded-lg ;
+}
+
+/* Pre */
+.markdown pre {
+    @apply mx-2;
+}

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -15,7 +15,9 @@
       <p class="text-sm md:text-base font-normal text-gray-600"><%= @article.created_at.localtime %></p>
     </div>
 
-    <%= markdown(@article.content_ja) %>
+    <div class="markdown">
+      <%= markdown(@article.content_ja)%>
+    </div>
 
   </div>
 


### PR DESCRIPTION
## 背景
tailwindcssを導入してからマークダウンにスタイルが当たっていなかった。

## やったこと
マークダウンのスタイルを修正。

## やらなかったこと

## UIの変更箇所

#### 変更前
<img width="968" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/129119764-82e4f18f-5aa9-4f94-af9d-19a5dd021afa.png">



#### 変更後
<img width="996" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/129119719-3f1528a5-637b-448e-b364-2820b650b4c1.png">
