### PR TITLE
adminしか編集ボタンが出ないように設定

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -10,7 +10,9 @@
       <%= link_to(articles_path) do %>
         <p class="text-nittai_teal md:text-sm text-green-500 font-bold">&lt; BACK TO ARTICLES</p>
       <% end %>
-      <%= link_to 'Edit', edit_article_path(@article) %>
+      <% if current_user&.admin? %>
+        <%= link_to 'Edit', edit_article_path(@article) %>
+      <% end %>
       <h1 class="font-bold font-sans break-normal text-gray-900 pt-6 pb-2 text-3xl md:text-4xl"><%= @article.title_ja %></h1>
       <p class="text-sm md:text-base font-normal text-gray-600"><%= @article.created_at.localtime %></p>
     </div>


### PR DESCRIPTION
## 背景
全員に記事のshow画面でeditボタンが表示されていた。

## やったこと
adminの場合しかeditが表示されないように変更した。

## やらなかったこと

## UIの変更箇所
変更前
<img width="822" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/130639142-11264a2d-1c29-4fe6-acac-6b50f0f9a2b3.png">

変更後

<img width="792" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/130638880-48b04c5d-dc5e-4cfb-88e6-8b57497bd773.png">

