### PR TITLE
サムネイルを追加できるようにした

### DIFF
--- a/.idea/blog_JT.iml
+++ b/.idea/blog_JT.iml
@@ -68,6 +68,7 @@
     <orderEntry type="library" scope="PROVIDED" name="globalid (v0.4.2, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="hashie (v4.1.0, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="i18n (v1.8.10, rbenv: 3.0.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="image_processing (v1.12.1, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="jbuilder (v2.11.2, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="jwt (v2.2.3, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="listen (v3.5.1, rbenv: 3.0.0) [gem]" level="application" />
@@ -75,6 +76,7 @@
     <orderEntry type="library" scope="PROVIDED" name="mail (v2.7.1, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="marcel (v1.0.1, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, rbenv: 3.0.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mini_magick (v4.11.0, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.0, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="minitest (v5.14.4, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.4.2, rbenv: 3.0.0) [gem]" level="application" />
@@ -125,6 +127,7 @@
     <orderEntry type="library" scope="PROVIDED" name="rubocop-rails (v2.11.3, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-rspec (v2.4.0, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.11.0, rbenv: 3.0.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ruby-vips (v2.1.3, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby2_keywords (v0.0.5, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="sass-rails (v6.0.0, rbenv: 3.0.0) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="sassc (v2.4.0, rbenv: 3.0.0) [gem]" level="application" />

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -53,6 +53,7 @@ class ArticlesController < ApplicationController
 
   # DELETE /articles/1 or /articles/1.json
   def destroy
+    @article.title_image.purge if @article.title_image.attached?
     @article.destroy
     respond_to do |format|
       format.html { redirect_to articles_url, notice: "Article was successfully destroyed." }
@@ -73,6 +74,6 @@ class ArticlesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def article_params
-      params.require(:article).permit(:title_ja, :content_ja)
+      params.require(:article).permit(:title_ja, :content_ja, :title_image)
     end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,4 +10,5 @@ class Article < ApplicationRecord
   has_many :comments, dependent: :destroy
 
   enum main_language: { japanese: 0, taiwanese: 1, english: 2 }
+  has_one_attached :title_image
 end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -19,6 +19,14 @@
       }
   </style>
   <div class="editor mx-auto w-10/12 flex flex-col text-gray-800 border border-gray-300 p-4 shadow-lg max-w-2xl">
+    <div class="field bg-gray-100 border border-gray-300 p-2 mb-4 outline-none">
+      <%= form.label :title_image %>
+      <%= form.file_field :title_image %>
+<!--      アップロードした画像があれば表示する-->
+      <% if article.title_image.attached? %>
+        <%= image_tag article.title_image %>
+      <% end %>
+    </div>
     <%= form.text_area :title_ja, class: "title bg-gray-100 border border-gray-300 p-2 mb-4 outline-none", spellcheck: "false", placeholder: "Title", type: "text" %>
     <%= form.text_area :content_ja, class: "uploadable description bg-gray-100 sec p-3 h-60 border border-gray-300 outline-none", spellcheck: "false", placeholder: "Describe everything about this post here" %>
     <!-- icons -->

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -5,7 +5,11 @@
         <%= link_to(article) do %>
           <div class="p-4 md:w-1/3">
             <div class="h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden">
-              <img class="lg:h-48 md:h-36 w-full object-cover object-center" src="https://dummyimage.com/720x400" alt="blog">
+              <% if article.title_image.attached? %>
+                <%= image_tag article.title_image %>
+              <% else %>
+                <img class="lg:h-48 md:h-36 w-full object-cover object-center" src="https://dummyimage.com/720x400" alt="blog">
+            <% end %>
               <div class="p-6">
                 <h2 class="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">CATEGORY</h2>
                 <h1 class="title-font text-lg font-medium text-gray-900 mb-3"><%= article.title_ja %></h1>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -13,8 +13,11 @@
       <% if current_user&.admin? %>
         <%= link_to 'Edit', edit_article_path(@article) %>
       <% end %>
+      <% if @article.title_image.attached? %>
+        <%= image_tag @article.title_image %>
+      <% end %>
       <h1 class="font-bold font-sans break-normal text-gray-900 pt-6 pb-2 text-3xl md:text-4xl"><%= @article.title_ja %></h1>
-      <p class="text-sm md:text-base font-normal text-gray-600"><%= @article.created_at.localtime %></p>
+      <p class="text-sm md:text-base font-normal text-gray-600"><%= @article.created_at.localtime.to_date %></p>
     </div>
 
     <div class="markdown">


### PR DESCRIPTION
## 背景
記事一覧ページの画像部分に画像を表示できるようにすることで、見た目をよくしたいと思っていた。

## やったこと
articleモデルに、title_imageを追加して記事ごとのサムネイルを設定できるようにした、

## やらなかったこと
記事一覧ページのサムネイル写真をリサイズしたい

## UIの変更箇所

<img width="952" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/131216992-dbeafa3b-7012-4fee-980c-19bdabf46f81.png">

<img width="1023" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/131217058-aca3db60-5f82-4671-bd7d-2324e15e7700.png">

<img width="1020" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/131217206-34d59af7-220f-4eba-ac8c-46e4f3561575.png">

