### PR TITLE
記事の一覧ページに本文の最初を表示する

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -13,8 +13,10 @@
               <div class="p-6">
                 <h2 class="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">TITLE</h2>
                 <h1 class="title-font text-lg font-medium text-gray-900 mb-3"><%= article.title_ja %></h1>
-                <p class="leading-relaxed mb-3">Photo booth fam kinfolk cold-pressed sriracha leggings jianbing
-                  microdosing tousled waistcoat.</p>
+<!--                <p class="leading-relaxed mb-3 markdown"><%#= markdown(article.content_ja).slice(0,100) %></p>-->
+                <div class="markdown">
+                  <%= markdown(article.content_ja).gsub(/<("[^"]*"|'[^']*'|[^'">])*>/, "").slice(0,50) %>
+                </div>
                 <div class="flex items-center flex-wrap ">
                   <a class="text-blue-500 inline-flex items-center md:mb-2 lg:mb-0">
                   </a>


### PR DESCRIPTION
## 背景
記事一覧に本文の情報を入れることで記事の内容を少しでもわかりやすくしたかった。

## やったこと
記事一覧ページのそれぞれに本文を少し表示した。

## やらなかったこと
本当は文字数ではなく、二行分だけ表示するみたいな感じにしたい。
こんな感じ、
![note_――つくる、つながる、とどける。](https://user-images.githubusercontent.com/71773200/131218641-c54aec04-6d66-4932-b35b-ef167685b7f1.png)

## UIの変更箇所
![日台one_](https://user-images.githubusercontent.com/71773200/131218676-b448d1f7-b86d-4576-b8c3-67b76ddd4e83.png)

