### PR TITLE
記事一覧ページのサムネイルをリサイズ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,7 @@ gem 'devise-i18n'
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 gem "omniauth-rails_csrf_protection"
+
+# Use ActiveStorage variant
+gem 'mini_magick', '~> 4.8'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,9 @@ GEM
     hashie (4.1.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jwt (2.2.3)
@@ -124,6 +127,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.0)
     minitest (5.14.4)
     msgpack (1.4.2)
@@ -250,6 +254,8 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.3)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -310,8 +316,10 @@ DEPENDENCIES
   devise
   devise-i18n
   factory_bot_rails
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  mini_magick (~> 4.8)
   mysql2 (~> 0.5)
   omniauth-facebook
   omniauth-google-oauth2

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -6,31 +6,30 @@
           <div class="p-4 md:w-1/3">
             <div class="h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden">
               <% if article.title_image.attached? %>
-                <%= image_tag article.title_image, alt: "blog", class: "lg:h-48 md:h-36 w-full object-cover object-center" %>
+                <%= image_tag article.title_image.variant(resize: "720x400^", crop: '720x400+0+0'), alt: "blog", class: "lg:h-48 md:h-36 w-full object-cover object-center"%>
               <% else %>
                 <img class="lg:h-48 md:h-36 w-full object-cover object-center" src="https://dummyimage.com/720x400" alt="blog">
               <% end %>
               <div class="p-6">
                 <h2 class="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">TITLE</h2>
                 <h1 class="title-font text-lg font-medium text-gray-900 mb-3"><%= article.title_ja %></h1>
-<!--                <p class="leading-relaxed mb-3 markdown"><%#= markdown(article.content_ja).slice(0,100) %></p>-->
                 <div class="markdown">
-                  <%= markdown(article.content_ja).gsub(/<("[^"]*"|'[^']*'|[^'">])*>/, "").slice(0,50) %>
+                  <%= markdown(article.content_ja).gsub(/<("[^"]*"|'[^']*'|[^'">])*>/, "").slice(0, 50) %>
                 </div>
                 <div class="flex items-center flex-wrap ">
                   <a class="text-blue-500 inline-flex items-center md:mb-2 lg:mb-0">
                   </a>
-                  <span class="text-gray-400 mr-3 inline-flex items-center lg:ml-auto md:ml-0 ml-auto leading-none text-sm pr-3 py-1 border-r-2 border-gray-200">
-                <svg class="w-4 h-4 mr-1" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
-                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                  <circle cx="12" cy="12" r="3"></circle>
-                </svg>1.2K
-              </span>
-                  <span class="text-gray-400 inline-flex items-center leading-none text-sm">
-                <svg class="w-4 h-4 mr-1" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
-                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"></path>
-                </svg>6
-              </span>
+<!--                  <span class="text-gray-400 mr-3 inline-flex items-center lg:ml-auto md:ml-0 ml-auto leading-none text-sm pr-3 py-1 border-r-2 border-gray-200">-->
+<!--                <svg class="w-4 h-4 mr-1" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">-->
+<!--                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>-->
+<!--                  <circle cx="12" cy="12" r="3"></circle>-->
+<!--                </svg>1.2K-->
+<!--              </span>-->
+<!--                  <span class="text-gray-400 inline-flex items-center leading-none text-sm">-->
+<!--                <svg class="w-4 h-4 mr-1" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">-->
+<!--                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"></path>-->
+<!--                </svg>6-->
+<!--              </span>-->
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 背景
サムネイル画像が縦長になるのを修正したかった。

## やったこと
縦長にならないようにリサイズできるようにした。

## やらなかったこと

## UIの変更箇所
変更前
<img width="463" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/131234825-46dde761-b104-442b-a530-500b991ddd84.png">


変更後
<img width="455" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/131234812-cf9945a6-0d7e-4b7c-bc71-268e86271afb.png">

