### PR TITLE
en,ja,zh-twのボタンをnavbarから消す

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -27,9 +27,9 @@
         </div>
 
         <div class="flex items-center mt-0">
-          <% I18n.available_locales.reject{|l| l == I18n.locale}.each do |locale| %>
-            <%= link_to(locale, i18n_url_for(params.permit.merge(locale: locale)), class: "px-2 py-1 mx-2 mt-2 text-sm font-medium text-nittai_whitegrey transition-colors duration-200 transform rounded-md md:mt-0 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-700") %>
-          <% end %>
+          <%# I18n.available_locales.reject{|l| l == I18n.locale}.each do |locale| %>
+            <%#= link_to(locale, i18n_url_for(params.permit.merge(locale: locale)), class: "px-2 py-1 mx-2 mt-2 text-sm font-medium text-nittai_whitegrey transition-colors duration-200 transform rounded-md md:mt-0 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-700") %>
+          <%# end %>
 <!--          <button class="hidden mx-4 text-gray-600 md:block dark:text-gray-200 hover:text-gray-700 dark:hover:text-gray-400 focus:text-gray-700 dark:focus:text-gray-400 focus:outline-none" aria-label="show notifications">-->
 <!--            <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">-->
 <!--              <path d="M15 17H20L18.5951 15.5951C18.2141 15.2141 18 14.6973 18 14.1585V11C18 8.38757 16.3304 6.16509 14 5.34142V5C14 3.89543 13.1046 3 12 3C10.8954 3 10 3.89543 10 5V5.34142C7.66962 6.16509 6 8.38757 6 11V14.1585C6 14.6973 5.78595 15.2141 5.40493 15.5951L4 17H9M15 17V18C15 19.6569 13.6569 21 12 21C10.3431 21 9 19.6569 9 18V17M15 17H9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>-->


### PR DESCRIPTION
## 背景
navbarに言語切り替え用のボタンを入れていたが、実はいらない。

## やったこと
ボタンを消した。

## やらなかったこと

## UIの変更箇所
<img width="935" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/131250022-0b39135e-ae38-4dea-9f37-52147b90ae64.png">

