### PR TITLE
S3の画像へのアクセスをCloudFront経由にする

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = 'http://assets.example.com'
+  config.asset_host = 'https://static.nittai-one.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
## 背景
これからブログを構成していく中で、表示速度を上げるためにCDNを使いたい。

## やったこと
以下の記事を参考にcloudfrontを適用した。
https://ryo10leo.hatenablog.com/entry/2020/01/21/031055

AWS側の設定は以下の記事を参考にした。
https://qiita.com/take18k_tech/items/5710ad9d00ea4c13ce36

## やらなかったこと

## UIの変更箇所
