### PR TITLE
記事一覧のサムネイル表示をcloudfrontにしたい

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -6,7 +6,7 @@
           <div class="p-4 md:w-1/3">
             <div class="h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden">
               <% if article.title_image.present? %>
-                <%= image_tag article.title_image.url, alt: "blog", class: "lg:h-48 md:h-36 w-full object-cover object-center"%>
+                <%= image_tag article.title_image.url, class: "lg:h-48 md:h-36 w-full object-cover object-center"%>
               <% else %>
                 <img class="lg:h-48 md:h-36 w-full object-cover object-center" src="https://dummyimage.com/720x400" alt="blog">
               <% end %>


### PR DESCRIPTION
## 背景
記事詳細ないのサムネイルはcloudfront経由になったが、記事一覧ページのサムネイルは直接S3を見に行っている。

## やったこと
画像表示のaltを削除

## やらなかったこと
もし次できなかったら、classを削除

## UIの変更箇所
