### PR TITLE
markdownの見た目を編集

### DIFF
--- a/app/javascript/css/tailwindcss.css
+++ b/app/javascript/css/tailwindcss.css
@@ -5,7 +5,7 @@
 /* Markdown Styles */
 /* Global */
 .markdown {
-    @apply leading-relaxed text-sm　font-sans;
+    @apply leading-relaxed text-base font-sans;
 }
 @screen sm {
     .markdown {
@@ -19,28 +19,34 @@
 }
 
 /* Headers */
-.markdown h1,
-.markdown h2 {
-    @apply text-xl my-6;
+.markdown h1 {
+    @apply text-3xl my-6 font-semibold border-b-2;
 }
-.markdown h3,
-.markdown h4,
+.markdown h2 {
+    @apply text-2xl my-6 font-semibold border-b-2;
+}
+.markdown h3 {
+    @apply text-xl my-3 font-semibold;
+}
+.markdown h4 {
+    @apply text-lg my-3 font-semibold;
+}
 .markdown h5,
 .markdown h6 {
-    @apply text-lg my-3 ;
+    @apply my-3 font-medium;
 }
-@screen sm {
-    .markdown h1,
-    .markdown h2 {
-        @apply text-2xl;
-    }
-    .markdown h3,
-    .markdown h4,
-    .markdown h5,
-    .markdown h6 {
-        @apply text-xl;
-    }
-}
+/*@screen sm {*/
+/*    .markdown h1,*/
+/*    .markdown h2 {*/
+/*        @apply text-2xl font-bold;*/
+/*    }*/
+/*    .markdown h3,*/
+/*    .markdown h4,*/
+/*    .markdown h5,*/
+/*    .markdown h6 {*/
+/*        @apply text-xl font-medium;*/
+/*    }*/
+/*}*/
 
 /* Links */
 .markdown a {
@@ -52,7 +58,7 @@
 
 /* Paragraph */
 .markdown p {
-    @apply mb-4 leading-8 md:leading-10 text-justify;
+    @apply mb-4 leading-6 md:leading-8 text-justify text-gray-700;
 }
 
 /* Lists */


### PR DESCRIPTION
## 背景
記事の詳細欄の見た目が少し悪かったので修正したいと思っていた。

## やったこと
hタグにボールドをつける、サイズを変える
pタグの１列の幅を調整

## やらなかったこと

## UIの変更箇所
### 変更前

![localhost_3000_articles_8_locale=ja (1)](https://user-images.githubusercontent.com/71773200/133531946-e8c86e8a-afa6-4d2b-a259-809b15f64475.png)

### 変更後
![localhost_3000_articles_8_locale=ja](https://user-images.githubusercontent.com/71773200/133531921-f58e1bac-d22a-40e4-b65f-f09e85445fc0.png)


