### PR TITLE
マークダウンのHタグと画像が翻訳されないように変更

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -45,6 +45,7 @@ class Article < ApplicationRecord
                                                          target_language_code: target_language_code
                                                        })
 
+    # <p translate=no>とそれに紐づく</p>を削除
     translated_content = response_content.translated_text.gsub(%r{(<p translate=no>|</p>)}, '')
 
     if main_language_japanese?


### PR DESCRIPTION
## 背景
マークダウンのHタグと画像が翻訳されてしまうことで、翻訳後の表示がおかしくなってしまっていた。

## やったこと
正規表現で#と画像部分を抜き出し```<p translate=no>~~</p>```に置き換えてから翻訳し、翻訳後は```<p translate=no>~~</p>```を削除することで対応。

## やらなかったこと

## UIの変更箇所
