### PR TITLE
記事ごとにogpが設定されるように変更

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,3 +1,8 @@
+<% if @locale == "ja" %>
+  <% set_meta_tags title: @article.title_ja, description: markdown(@article.content_ja).gsub(/<("[^"]*"|'[^']*'|[^'">])*>/, ""), og: { title: @article.title_ja, image: @article.title_image.url } %>
+<% else %>
+  <% set_meta_tags title: @article.title_zh_tw, description: markdown(@article.content_zh_tw).gsub(/<("[^"]*"|'[^']*'|[^'">])*>/, ""), og: { title: @article.title_zh_tw, image: @article.title_image.url } %>
+<% end %>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
 
 <!--Container-->


### PR DESCRIPTION
## 背景
今まではサイトで共通のタイトルや説明文や画像が表示される設定だっった。
次は記事をシェアしたときにそれらの情報が載るように設定変更をしたい。

## やったこと
記事の詳細ページをシェアしたときに記事ごとのogpが生成されるように変更した。

## やらなかったこと

## UIの変更箇所
