### PR TITLE
機械翻訳された文章はそれがわかるように伝える文章を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -83,6 +83,16 @@ class Article < ApplicationRecord
     content
   end
 
+  def display_translate_caution(language)
+    if language == 'ja' && main_language == "taiwanese"
+      "※この記事は機械翻訳された文章です"
+    elsif language == 'zh-TW' && main_language == "japanese"
+      "※這篇文章是機器翻譯的句子"
+    else
+      ""
+    end
+  end
+
   private
 
   def main_language_japanese?

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -18,6 +18,9 @@
       <h1 class="font-bold font-sans break-normal text-gray-900 pt-6 pb-2 text-2xl md:text-3xl">
         <%= @article.locale_judge_title(@locale) %>
       </h1>
+      <p class="text-xs md:text-sm font-normal text-red-700">
+        <%= @article.display_translate_caution(@locale) %>
+      </p>
       <p class="text-sm md:text-base font-normal text-gray-600">
         <time datetime="<%= @article.created_at %>">
           <%= I18n.l(@article.created_at.in_time_zone('Asia/Tokyo'), format: :long) %>


### PR DESCRIPTION
## 背景
機械翻訳で不自然になった文章に違和感を持ったユーザーさんが離れるのを防ぐため

## やったこと
記事の上の方に注意書きを追加

## やらなかったこと

## UIの変更箇所
#### 台灣華語
<img width="286" alt="降價測試___日台one_" src="https://user-images.githubusercontent.com/71773200/135734173-ed1b7c32-2e31-4ac8-82fe-bd8d48830713.png">

#### 日本語
<img width="290" alt="おれが欲しい___日台one_" src="https://user-images.githubusercontent.com/71773200/135734179-9910790a-c3ad-4aa3-9cea-d4e2d2caa737.png">

