### PR TITLE
記事一覧用のカラムを追加

### DIFF
--- a/db/migrate/20211003225546_add_visible_to_articles.rb
+++ b/db/migrate/20211003225546_add_visible_to_articles.rb
@@ -1,0 +1,5 @@
+class AddVisibleToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :visible_list, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_16_130103) do
+ActiveRecord::Schema.define(version: 2021_10_03_225546) do
 
   create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title_ja"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2021_09_16_130103) do
     t.integer "main_language", null: false
     t.integer "user_id", null: false
     t.string "title_image"
+    t.boolean "visible_list", default: true, null: false
   end
 
   create_table "attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/lib/tasks/add_visible_information_at_index.rake
+++ b/lib/tasks/add_visible_information_at_index.rake
@@ -1,0 +1,9 @@
+namespace :add_value_to_column do
+  desc "記事一覧に表示するかしないかを設定するカラムにtrueを入れる"
+  task add_visible_information_at_index: :environment do
+    articles = Article.all
+    articles.each do |article|
+      article.update!(visible_list: true)
+    end
+  end
+end


### PR DESCRIPTION
## 背景
記事一覧に利用規約が見えてしまっているので、これを見えないようにしたかった。

## やったこと
articleテーブルにカラムを追加し、これを記事一覧のところに使う予定。

## やらなかったこと

## UIの変更箇所
