### PR TITLE
safariでのyoutube表示の修正

### DIFF
--- a/app/javascript/css/tailwindcss.css
+++ b/app/javascript/css/tailwindcss.css
@@ -84,5 +84,5 @@
 }
 
 .youtube iframe {
-    @apply absolute h-full w-full object-cover;
+    @apply absolute h-full w-full object-contain;
 }


### PR DESCRIPTION
## 背景
chromeでは問題なく中心にyoutubeのiframeが表示されるが、iPhoneのsafariで表示が変になっていました。

## やったこと
以下の記事を参考に修正した。
後で確認してダメだったらリバートする。
https://teratail.com/questions/167159

## やらなかったこと

## UIの変更箇所
