### PR TITLE
まとまりがなくなってしまうため日本と台湾のタグを分けた

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,14 +6,14 @@ class ArticlesController < ApplicationController
   # GET /articles or /articles.json
   def index
     @articles = Article.all
-    @tags = Article.tag_counts_on(:tags).order('count DESC')
+    @tags = Article.tag_counts_on_locale(@locale).order('count DESC').limit(30)
     @articles = Article.tagged_with(params[:tag_name].to_s) if params[:tag_name]
   end
 
   # GET /articles/1 or /articles/1.json
   def show
     @user = @article.user
-    @tags = @article.tag_counts_on(:tags)
+    @tags = @article.tag_counts_on_locale(@locale)
     return if browsing_authority?
 
     flash[:notice] = "この記事を閲覧する権限がありません"
@@ -110,7 +110,8 @@ class ArticlesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def article_params
-    params.require(:article).permit(:title_ja, :content_ja, :title_zh_tw, :content_zh_tw, :title_image, :tag_list,
+    params.require(:article).permit(:title_ja, :content_ja, :title_zh_tw, :content_zh_tw, :title_image, :japan_tag_list,
+                                    :taiwan_tag_list,
                                     place_attributes: [:id, :country, :prefecture_japan_id, :prefecture_taiwan_id])
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,7 +3,6 @@ class Article < ApplicationRecord
   has_one :place, dependent: :destroy
   accepts_nested_attributes_for :place
 
-  has_many :tags, dependent: :destroy
   has_many :comments, dependent: :destroy
 
   enum main_language: { japanese: 0, taiwanese: 1, english: 2 }
@@ -11,10 +10,26 @@ class Article < ApplicationRecord
 
   mount_uploader :title_image, TitleImageUploader
 
-  acts_as_taggable
+  acts_as_taggable_on :japan_tags, :taiwan_tags
 
   scope :visible, -> { where(visible_list: true) }
   scope :recent, ->(limit=99) { order(id: "DESC").limit(limit) }
+
+  def self.tag_counts_on_locale(language)
+    if language == 'ja'
+      tag_counts_on(:japan_tags)
+    else
+      tag_counts_on(:taiwan_tags)
+    end
+  end
+
+  def tag_counts_on_locale(language)
+    if language == 'ja'
+      tag_counts_on(:japan_tags)
+    else
+      tag_counts_on(:taiwan_tags)
+    end
+  end
 
   def translate_title_and_content
     translate_client = Aws::Translate::Client.new(

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -41,7 +41,10 @@
       <% end %>
     </div>
     <div class="field bg-gray-100 border border-gray-300 p-2 mb-4 outline-none">
-      <%= form.text_field :tag_list, value: article.tag_list.join(','), class: "bg-transparent w-full", placeholder: "tag1, tag2, tag3..., max tag6" %>
+      <%= form.text_field :japan_tag_list, value: article.japan_tag_list.join(','), class: "bg-transparent w-full", placeholder: "japan tag1, tag2, max tag3" %>
+    </div>
+    <div class="field bg-gray-100 border border-gray-300 p-2 mb-4 outline-none">
+      <%= form.text_field :taiwan_tag_list, value: article.taiwan_tag_list.join(','), class: "bg-transparent w-full", placeholder: "taiwan tag1, tag2, max tag3" %>
     </div>
 
     <% if current_user.native_language == "japanese" %>


### PR DESCRIPTION
## 背景
当初は台湾語と日本語のタグを一緒に扱うつもりだったか、一覧の時の見た目がよくないので分ける運用にする。

## やったこと
tagを日本と台湾のに種類に変更した。

## やらなかったこと

## UIの変更箇所
