### PR TITLE
no translateで改行されないようにした

### DIFF
--- a/app/javascript/packs/article/image_upload_press_button.js
+++ b/app/javascript/packs/article/image_upload_press_button.js
@@ -19,7 +19,7 @@ window.onload = function(){
 
     document.getElementById("image-up").onclick=function(){
         let area = document.getElementById('text-editor');
-        let text = "<p translate=no></p>";
+        let text = "<span translate=no></span>";
         //カーソルの位置を基準に前後を分割して、その間に文字列を挿入
         area.value = area.value.substr(0, area.selectionStart)
             + text

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -38,7 +38,7 @@ class Article < ApplicationRecord
       secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key)
     )
 
-    replace_tag = '<p translate=no>\&</p>'
+    replace_tag = '<span translate=no>\&</span>'
 
     if main_language_japanese?
       target_title = title_ja
@@ -67,8 +67,8 @@ class Article < ApplicationRecord
                                                        })
 
     # <p translate=no>とそれに紐づく</p>を削除
-    translated_title = response_title.translated_text.gsub(%r{(<p translate=no>|</p>)}, '')
-    translated_content = response_content.translated_text.gsub(%r{(<p translate=no>|</p>)}, '')
+    translated_title = response_title.translated_text.gsub(%r{(<span translate=no>|</span>)}, '')
+    translated_content = response_content.translated_text.gsub(%r{(<span translate=no>|</span>)}, '')
 
     if main_language_japanese?
       self.title_zh_tw = translated_title
@@ -89,7 +89,7 @@ class Article < ApplicationRecord
     # contentがblankなら空白を返す
     return '' if title.blank?
 
-    title
+    title.gsub(%r{(<span translate=no>|</span>)}, '')
   end
 
   def locale_judge_content(language)


### PR DESCRIPTION
## 背景
no translateを改行されてしまう問題や、タイトルのところにタグが残ってしまう問題が発生した。

## やったこと
直した

## やらなかったこと

## UIの変更箇所
