### PR TITLE
すでにアップロードされているs3の画像を圧縮

### DIFF
--- a/app/util/image_compressor.rb
+++ b/app/util/image_compressor.rb
@@ -1,7 +1,7 @@
 require 'aws-sdk-s3'
 
 class ImageCompressor
-  def self.optimize(key_num, width=640, height=640)
+  def self.optimize(key_num, width=640, height=640, resolution=80)
     # ① clientの作成
     s3_client = Aws::S3::Client.new(
       region: "ap-northeast-1",
@@ -14,21 +14,16 @@ class ImageCompressor
     if file.content_type.match?(/image/)
       # ④ 画像のリサイズ・圧縮
       image_file = file.body.read
-      # image = Magick::ImageList.new("https://blog-jt-bucket01.s3.ap-northeast-1.amazonaws.com/uploads/tmp/1633870275-336983723201947-0027-3329/IMG_7034.JPG").first
       image = MiniMagick::Image.read(image_file)
-      # image.resize("640x640")
       image.resize("#{width}x#{height}")
+      image.quality(resolution)
       # ⑤ content-typeを取得
       compressed_image = image
       type = file.content_type
       # ⑥ 既存のS3オブジェクトの画像をcompressed_imageに差し替える。
-      s3 = Aws::S3::Resource.new(
-        region: "ap-northeast-1",
-        access_key_id: Rails.application.credentials.dig(:aws, :access_key_id),
-        secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key)
-      )
+      s3 = Aws::S3::Resource.new(region: "ap-northeast-1")
       bucket = s3.bucket("blog-jt-bucket01")
-      bucket.object(key_num).upload_file(File.open(compressed_image.path), content_type: type)
+      bucket.put_object(key: key_num, body: File.open(compressed_image.path), content_type: type)
     end
   end
 end


### PR DESCRIPTION
## 背景
すでにアップロードされている画像が1000近くあったので、手作業で圧縮することは断念した。


## やったこと
s3のバケットポリシーのレベルをさげないとすでにアップロードされているkeyを取得できなかったので、短時間で終わらせた。
IAMのaccess_key_idとsecret_access_keyでできると思ったが、いろいろ試してもできなかったのでこれに落ち着いた。

バケットポリシーは以下
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "ListObjectsInBucket",
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:ListBucket",
            "Resource": "arn:aws:s3:::blog-jt-bucket01"
        },
        {
            "Sid": "AllObjectActions",
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:*Object*",
            "Resource": "arn:aws:s3:::blog-jt-bucket01/*"
        }
    ]
}

```

```
s3_resources = Aws::S3::Client.new(
      region: "ap-northeast-1",
      access_key_id: Rails.application.credentials.dig(:aws, :access_key_id),
      secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key)
)

bucket_name = "blog-jt-bucket01"

key_array = []

s3_resources.list_objects(:bucket => bucket_name, :prefix => 'uploads/attachment').contents.each do |object|
  key_array << object.key
end

key_array.each do |key|
#適宜圧縮細部は変更
   ImageCompressor.optimize(key, 640, 640)
end
```

## やらなかったこと

## UIの変更箇所
