### PR TITLE
記事番号が存在しない時にエラーを回避するように変更

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -107,6 +107,10 @@ class ArticlesController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_article
     @article = Article.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    flash[:notice] = "記事は存在しません。"
+    Bugsnag.notify(ActiveRecord::RecordNotFound)
+    redirect_to root_url
   end
 
   # Only allow a list of trusted parameters through.


### PR DESCRIPTION
## 背景
以下のエラーを修正
https://app.bugsnag.com/hobby-10/nittai-one/errors/619e3c169365d0000865b41c?filters[event.since]=30d&filters[error.status]=open

## やったこと

## やらなかったこと

## UIの変更箇所
